### PR TITLE
Add dispose service provider

### DIFF
--- a/src/Console/src/ConsoleGo/Program.cs
+++ b/src/Console/src/ConsoleGo/Program.cs
@@ -21,7 +21,7 @@ try
                 .AddAppSettingsJson("appsettings.json")
                 .Build();
 
-            var provider = new ServiceCollection()
+            using var provider = new ServiceCollection()
                 .AddServices()
                 .AddConfiguration(configuration)
                 .AddLogging(builder => builder
@@ -80,13 +80,6 @@ try
         provider.GetRequiredService<ILogger<Program>>()
             .LogCritical(ex, ex.Message);
     }
-#if (!useSerilog)
-    finally
-    {
-        provider.GetRequiredService<ILoggerFactory>()
-            .Dispose();
-    }
-#endif
 #endif
 }
 catch (Exception ex)


### PR DESCRIPTION
When service provider is dispose then loggers will be disposed as well. This way we don't need explicit logger disposal and all the log messages will reach their destination.  