### PR TITLE
Add condition to run push step only for master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Pack
       run: nuget pack .nuspec -NoDefaultExcludes -OutputDirectory bin -Version ${{ env.GitVersion_FullSemVer }}
  
-    - name: Push    
+    - name: Push  
+      if: github.head_ref == 'refs/heads/main'
       run: dotnet nuget push "bin/*.nupkg" -k ${{ secrets.PACKAGES_TOKEN }} -s https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json --skip-duplicate
 


### PR DESCRIPTION
Added condition to run step only for main branch.
Solution found at https://stackoverflow.com/questions/58139406/only-run-job-on-specific-branch-with-github-actions
